### PR TITLE
Use body_entered signal object for goal handling

### DIFF
--- a/scenes/goal.gd
+++ b/scenes/goal.gd
@@ -16,7 +16,7 @@ func _ready() -> void:
 		is_right_goal = global_position.x > half_width
 
 	# Подключаем сигнал
-	if not is_connected("body_entered", Callable(self, "_on_body_entered")):
+	if not body_entered.is_connected(_on_body_entered):
 		body_entered.connect(_on_body_entered)
 
 func _on_body_entered(body: Node) -> void:


### PR DESCRIPTION
## Summary
- Simplify goal signal hookup by using the `body_entered` signal object directly

## Testing
- `/tmp/godot/Godot_v4.3-stable_linux.x86_64 --headless -s test_goal.gd`
- `/tmp/godot/Godot_v4.3-stable_linux.x86_64 --headless scenes/menu.tscn --quit` *(fails: Imported resources missing)*

------
https://chatgpt.com/codex/tasks/task_e_6895f010b9f08320abafc2b919a800b0