### PR TITLE
Fix goal side detection using collision shape and place goal areas

### DIFF
--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -122,20 +122,21 @@ ball_path = NodePath("../Ball")
 player_path = NodePath("../PlayerPaddle")
 
 [node name="GoalAreaRight" type="Area2D" parent="."]
+position = Vector2(1673.25, 531.5)
 script = ExtResource("6_u5sy4")
+is_right_goal = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="GoalAreaRight"]
-position = Vector2(1673.25, 531.5)
-scale = Vector2(0.719435, 0.941814)
+position = Vector2(0, 0)
 shape = SubResource("RectangleShape2D_vtaks")
 
 [node name="GoalAreaLeft" type="Area2D" parent="."]
-scale = Vector2(0.910295, 0.999548)
+position = Vector2(93.3764, 532.241)
 script = ExtResource("6_u5sy4")
+is_right_goal = false
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="GoalAreaLeft"]
-position = Vector2(93.3764, 532.241)
-scale = Vector2(0.725053, 1.06231)
+position = Vector2(0, 0)
 shape = SubResource("RectangleShape2D_vtaks")
 
 [node name="GoalSound" type="AudioStreamPlayer" parent="."]

--- a/scenes/goal.gd
+++ b/scenes/goal.gd
@@ -15,10 +15,11 @@ extends Area2D
 @onready var _sound: AudioStreamPlayer = get_parent().get_node_or_null("GoalSound")
 
 func _ready() -> void:
-	# Определяем сторону ворот автоматически, если не в редакторе
-	if not Engine.is_editor_hint():
-		var half_width := get_viewport_rect().size.x * 0.5
-		is_right_goal = global_position.x > half_width
+        # Определяем сторону ворот автоматически по позиции коллизии
+        if not Engine.is_editor_hint():
+                var shape_pos := $CollisionShape2D.global_position.x
+                var half_width := get_viewport_rect().size.x * 0.5
+                is_right_goal = shape_pos > half_width
 
 func _on_body_entered(body: Node) -> void:
 	# Реагируем только на мяч


### PR DESCRIPTION
## Summary
- Determine goal side by collision shape global position to avoid offsets
- Position goal areas directly and zero their collision shapes, explicitly tagging left/right goals

## Testing
- `godot3-server --path . -s scripts/test_goals.gd` *(failed: command not found)*
- `/tmp/godot/Godot_v4.4.1-stable_linux.x86_64 --headless --path . -s scripts/test_goals.gd` *(failed: resource import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68960e7bbbc48320a5f284e7f383b792