### PR TITLE
feat: dynamic paddle speed boost

### DIFF
--- a/scenes/ai_paddle.gd
+++ b/scenes/ai_paddle.gd
@@ -97,9 +97,12 @@ func _handle_ball_collisions() -> void:
 		var col: KinematicCollision2D = get_slide_collision(i)
 		var rb := col.get_collider() as RigidBody2D
 		if rb and rb.is_in_group("ball"):
-			var info: Dictionary = Utils.reflect(rb.linear_velocity, col.get_normal(), velocity, 1.07)
+                       var normal: Vector2 = col.get_normal()
+                       var proj_speed: float = velocity.project(normal).length()
+                       var boost: float = proj_speed * 0.0001
+                       var info: Dictionary = Utils.reflect(rb.linear_velocity, normal, velocity, boost)
 
-			if _is_first_hit:
+                       if _is_first_hit:
 				var sign_dir: float = sign(rb.global_position.y - _player.global_position.y)
 				info["vel"].y += sign_dir * FIRST_HIT_DEVIATION_Y
 				_is_first_hit = false

--- a/scenes/ball.gd
+++ b/scenes/ball.gd
@@ -46,12 +46,8 @@ func _teleport_to_spawn() -> void:
 	sleeping = false
 
 func _integrate_forces(state):
-	# Boost speed slightly on every ricochet
-	if state.get_contact_count() > 0:
-		linear_velocity *= 1.05  # +5 % per bounce
-
-	var v := linear_velocity.length()
-	if v > SPEED_LIMIT:
-		linear_velocity = linear_velocity.normalized() * SPEED_LIMIT
-	elif v > 0.0 and v < MIN_SPEED:
-		linear_velocity = linear_velocity.normalized() * MIN_SPEED
+       var v := linear_velocity.length()
+       if v > SPEED_LIMIT:
+               linear_velocity = linear_velocity.normalized() * SPEED_LIMIT
+       elif v > 0.0 and v < MIN_SPEED:
+               linear_velocity = linear_velocity.normalized() * MIN_SPEED

--- a/scenes/player_paddle.gd
+++ b/scenes/player_paddle.gd
@@ -75,9 +75,12 @@ func _handle_ball_collisions() -> void:
 		var col: KinematicCollision2D = get_slide_collision(i)
 		var rb := col.get_collider() as RigidBody2D
 		if rb and rb.is_in_group("ball"):
-			var info: Dictionary = Utils.reflect(rb.linear_velocity, col.get_normal(), velocity, 1.07)
-			rb.linear_velocity  = info["vel"]
-			rb.angular_velocity = info["spin"]
+                       var normal: Vector2 = col.get_normal()
+                       var proj_speed: float = velocity.project(normal).length()
+                       var boost: float = proj_speed * 0.0001
+                       var info: Dictionary = Utils.reflect(rb.linear_velocity, normal, velocity, boost)
+                       rb.linear_velocity  = info["vel"]
+                       rb.angular_velocity = info["spin"]
 
 func _resolve_half_size() -> Vector2:
 	# 1) Явное значение

--- a/scripts/utils.gd
+++ b/scripts/utils.gd
@@ -6,22 +6,23 @@ extends Node
 class_name Utils
 
 # Отражение мяча от ракетки с учётом спина (вращения)
+# speed_boost — добавочный множитель скорости от движения ракетки
 # Возвращает Dictionary:
 #   vel  – новый вектор скорости мяча после столкновения
 #   spin – добавленное вращение (для эффекта Магнуса)
 static func reflect(
-	old_vel: Vector2,
-	normal: Vector2,
-	paddle_vel: Vector2,
-	boost: float = 1.0
+        old_vel: Vector2,
+        normal: Vector2,
+        paddle_vel: Vector2,
+        speed_boost: float = 0.0
 ) -> Dictionary:
-	# 1. Отражаем скорость от нормали (стандартный bounce)
-	var v_new: Vector2 = old_vel.bounce(normal) * boost
+       # 1. Отражаем скорость от нормали и добавляем прирост от движения ракетки
+       var v_new: Vector2 = old_vel.bounce(normal) * (1.0 + speed_boost)
 
-	# 2. Вычисляем спин (по вертикальной составляющей скорости ракетки)
-	#    — вниз = backspin, вверх = topspin
-	var spin: float = clamp(paddle_vel.y * 0.01, -200.0, 200.0)
+       # 2. Вычисляем спин (по вертикальной составляющей скорости ракетки)
+       #    — вниз = backspin, вверх = topspin
+       var spin: float = clamp(paddle_vel.y * 0.01, -200.0, 200.0)
 
-	return { "vel": v_new, "spin": spin }
+       return { "vel": v_new, "spin": spin }
 
 # (Можно добавить и другие утилиты по мере роста проекта)


### PR DESCRIPTION
## Summary
- remove constant ricochet acceleration on the ball
- allow Utils.reflect to apply extra speed boost from paddles
- paddles compute boost from their velocity projection on the collision normal

## Testing
- `godot --headless --quit` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*

------
https://chatgpt.com/codex/tasks/task_e_6897555479b083209c189637c23b2f15