### PR TITLE
Add AI miss chance

### DIFF
--- a/scenes/ai_paddle.gd
+++ b/scenes/ai_paddle.gd
@@ -98,6 +98,10 @@ func _handle_ball_collisions() -> void:
 		var col: KinematicCollision2D = get_slide_collision(i)
 		var rb := col.get_collider() as RigidBody2D
 		if rb and rb.is_in_group("ball"):
+			var miss_skip: float = pow(1.0 - skill, 3.0)
+			if randf() < miss_skip:
+				continue
+
 			var normal: Vector2 = col.get_normal()
 			var proj_speed: float = velocity.project(normal).length()
 			var boost: float = proj_speed * 0.0001


### PR DESCRIPTION
## Summary
- Allow AI paddle to intentionally miss with probability based on skill

## Testing
- `godot --headless --check project.godot` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68975c31b7f48320b1345df306bc0a05